### PR TITLE
fix for Safari 7 polyfill detection

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -134,12 +134,12 @@ PolyfillInjectorPlugin.prototype.apply = function apply(compiler) {
                         return;
                     }
 
-                    // (function(main) {
+                    // .call(window, function(main) {
                     //   load polyfills if needed, then execute main()
                     // }) (function() { normal application code goes here... });
                     const source = new ConcatSource(
                         injector,
-                        '(function() {\n',
+                        '.call(window, function() {\n',
                         compilation.assets[file],
                         '\n});'
                     );


### PR DESCRIPTION
I get the following error on Ipad safari 7

`TypeError: 'undefined' is not a valid argument for 'in' (evaluating ''Promise' in this')`

An example detector is :

`"Promise" in this`

However 'this' is undefined on iPad

Changing the detector call to be 

`.call(window, main)`

ensures that 'this' is window